### PR TITLE
Støtte for flere instanser av mock service worker samtidig

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,18 @@ i identrutinene. Det er derfor viktig å benytte riktig begrep i kommunikasjon m
 5. Appen nås på <http://localhost:5173/attestasjon>
 
 NB! Anbefaler sette opp [ModHeader](https://modheader.com/) extension på Chrome for å sende med Obo-token i `Authorization` header når du kjører mot backend lokalt da den krever at token inneholder NavIdent.
+
+### Flere instanser med msw samtidig
+
+```bash
+# Terminal 1
+pnpm run dev          # Default på port 5173
+
+# Terminal 2
+PORT=5174 pnpm run dev
+
+# Terminal 3
+PORT=5175 pnpm run dev
+```
+
+Dette gjør at hver instans har sin egen MSW worker og kan kjøre uavhengig av hverandre.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:5173/attestasjon",
+    baseURL: `http://localhost:${process.env.PORT || 5173}/attestasjon`,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on",
@@ -71,7 +71,7 @@ export default defineConfig({
   ],
   webServer: {
     command: "pnpm run dev:backend",
-    url: "http://localhost:5173/attestasjon",
+    url: `http://localhost:${process.env.PORT || 5173}/attestasjon`,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.10.4'
+const PACKAGE_VERSION = '2.10.5'
 const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,7 +9,7 @@ const server = express();
 
 const corsAllowedOrigin = [
   /https:\/\/utbetalingsportalen(-[a-z][a-z0-9])?(.ansatt|.intern)(.dev)?.nav.no/,
-  "http://localhost:5173",
+  /http:\/\/localhost:(517[3-9]|518[0-9]|519[0-9]|3000)/,
 ];
 
 server.use(cors({ origin: corsAllowedOrigin }));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,8 +7,13 @@ const startMsw = async () => {
   if (import.meta.env.MODE === "mock") {
     try {
       const { worker } = await import("../mock/browser");
+
       await worker.start({
+        serviceWorker: {
+          url: "/mockServiceWorker.js",
+        },
         onUnhandledRequest: "bypass", // for assets o.l.
+        quiet: false,
       });
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,9 +8,13 @@ const startMsw = async () => {
     try {
       const { worker } = await import("../mock/browser");
 
+      // Unngår konflikt hvis man kjører flere lokale apper med msw samtidig
+      const port = window.location.port || "5173";
+      const serviceWorkerUrl = `/mockServiceWorker-${port}.js`;
+
       await worker.start({
         serviceWorker: {
-          url: "/mockServiceWorker.js",
+          url: serviceWorkerUrl,
         },
         onUnhandledRequest: "bypass", // for assets o.l.
         quiet: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,14 @@ export default defineConfig(({ mode }) => {
           },
         }),
         ...(mode === "mock" && {
+          // kan hende dette kan fjernes?
           "^/mockServiceWorker\\.js$": {
+            target: `http://localhost:${serverPort}`,
+            rewrite: () => "/attestasjon/mockServiceWorker.js",
+            changeOrigin: false,
+          },
+          // for å håndtere flere instanser på forskjellige porter
+          [`^/mockServiceWorker-${serverPort}\\.js$`]: {
             target: `http://localhost:${serverPort}`,
             rewrite: () => "/attestasjon/mockServiceWorker.js",
             changeOrigin: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,50 +5,56 @@ import { defineConfig } from "vite";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 import EnvironmentPlugin from "vite-plugin-environment";
 
-export default defineConfig(({ mode }) => ({
-  base: "/attestasjon",
-  build: {
-    rollupOptions: {
-      input: resolve(__dirname, "src/App.tsx"),
-      preserveEntrySignatures: "exports-only",
-      external: ["react", "react-dom"],
-      output: {
-        entryFileNames: "bundle.js",
-        format: "esm",
+export default defineConfig(({ mode }) => {
+  const serverPort = process.env.PORT || 5173;
+
+  return {
+    base: "/attestasjon",
+    build: {
+      rollupOptions: {
+        input: resolve(__dirname, "src/App.tsx"),
+        preserveEntrySignatures: "exports-only",
+        external: ["react", "react-dom"],
+        output: {
+          entryFileNames: "bundle.js",
+          format: "esm",
+        },
       },
     },
-  },
-  css: {
-    modules: {
-      generateScopedName: "[name]__[local]___[hash:base64:5]",
+    css: {
+      modules: {
+        generateScopedName: "[name]__[local]___[hash:base64:5]",
+      },
     },
-  },
-  server: {
-    proxy: {
-      ...((mode === "backend" || /^.*-q1$/.test(mode)) && {
-        "/oppdrag-api/api/v1": {
-          target: /^.*-q1$/.test(mode)
-            ? "https://sokos-oppdrag.intern.dev.nav.no"
-            : "http://localhost:8080",
-          rewrite: (path: string) => path.replace(/^\/oppdrag-api/, ""),
-          changeOrigin: true,
-          secure: /^.*-q1$/.test(mode),
-        },
-      }),
-      ...(mode === "mock" && {
-        "/mockServiceWorker.js": {
-          target: "http://localhost:5173",
-          rewrite: () => "attestasjon/mockServiceWorker.js",
-        },
-      }),
+    server: {
+      port: Number(serverPort),
+      proxy: {
+        ...((mode === "backend" || /^.*-q1$/.test(mode)) && {
+          "/oppdrag-api/api/v1": {
+            target: /^.*-q1$/.test(mode)
+              ? "https://sokos-oppdrag.intern.dev.nav.no"
+              : "http://localhost:8080",
+            rewrite: (path: string) => path.replace(/^\/oppdrag-api/, ""),
+            changeOrigin: true,
+            secure: /^.*-q1$/.test(mode),
+          },
+        }),
+        ...(mode === "mock" && {
+          "^/mockServiceWorker\\.js$": {
+            target: `http://localhost:${serverPort}`,
+            rewrite: () => "/attestasjon/mockServiceWorker.js",
+            changeOrigin: false,
+          },
+        }),
+      },
     },
-  },
-  plugins: [
-    react(),
-    cssInjectedByJsPlugin(),
-    EnvironmentPlugin({
-      NODE_ENV: process.env.NODE_ENV || "development",
-    }),
-    terser(),
-  ],
-}));
+    plugins: [
+      react(),
+      cssInjectedByJsPlugin(),
+      EnvironmentPlugin({
+        NODE_ENV: process.env.NODE_ENV || "development",
+      }),
+      terser(),
+    ],
+  };
+});


### PR DESCRIPTION
Gjør at msw kan kjøres lokalt fra flere separate instanser samtidig. Trenger dette for å kunne kjøre lokalt i Utbetalingsportalen